### PR TITLE
change yaml_db repo for o2web/yaml_db

### DIFF
--- a/templates/Gemfile.tt
+++ b/templates/Gemfile.tt
@@ -58,7 +58,7 @@ gem 'whenever', require: false
 # gem 'que'
 
 # Database
-gem 'yaml_db'
+gem 'yaml_db', github: 'o2web/yaml_db'
 # gem 'goldiloader'
 # gem 'paranoia', '~> 2.0'
 


### PR DESCRIPTION
Get fixes on yaml_db from o2web fork to allow load of data with foreign_key constraints.
